### PR TITLE
Support passing string to document spec

### DIFF
--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -692,7 +692,11 @@
      (defmacro >def
        "Simple pass-through to `s/def`, except it strips the
        specs in production – use for data specs you don't need
-       in production when you want to minimise your build size."
+       in production when you want to minimise your build size.
+
+       You can optionally send a documentation string as the second parameter, this
+       is intended to be informational for the code reader, current this is not stored
+       anywhere, meaning you can't access this string at runtime."
        ([k spec-form]
         (when (cfg/get-env-config)
           (cond-> `(s/def ~k ~spec-form)

--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -693,11 +693,12 @@
        "Simple pass-through to `s/def`, except it strips the
        specs in production – use for data specs you don't need
        in production when you want to minimise your build size."
-       [k spec-form]
-       (when (cfg/get-env-config)
-         (cond-> `(s/def ~k ~spec-form)
-           (cljs-env? &env) clj->cljs)))
-
+       ([k spec-form]
+        (when (cfg/get-env-config)
+          (cond-> `(s/def ~k ~spec-form)
+            (cljs-env? &env) clj->cljs)))
+       ([k _doc spec-form]
+        `(>def ~k ~spec-form)))
 
      (s/def ::>fdef-args
        (s/and seq?                                          ;REVIEW


### PR DESCRIPTION
The string is discarded, this is intended to inform the person reading the code later,
it isn't stored anywhere, so currently you can't get this value by code.