### PR TITLE
Fix specs and emit specs from >def/>fdef unless explicitly disabled

### DIFF
--- a/src/main/com/fulcrologic/guardrails/config.cljc
+++ b/src/main/com/fulcrologic/guardrails/config.cljc
@@ -17,9 +17,8 @@
 ;; This isn't particularly pretty, but it's how we avoid
 ;; having ClojureScript as a required dependency on Clojure
 #?(:clj (try
-          (do
-            (ns-unalias (find-ns 'com.fulcrologic.guardrails.utils) 'cljs-env)
-            (require '[cljs.env :as cljs-env]))
+          (ns-unalias (find-ns 'com.fulcrologic.guardrails.utils) 'cljs-env)
+          (require '[cljs.env :as cljs-env])
           (catch Exception _ (require '[com.fulcrologic.guardrails.stubs.cljs-env :as cljs-env]))))
 
 (def default-config

--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -645,7 +645,7 @@
 
      (defmacro emit-specs? []
        (get (cfg/get-env-config) :emit-spec? true))
-     
+
      ;;;; Main macros and public API
 
      (s/def ::>defn-args
@@ -667,7 +667,7 @@
        {:arglists '([name doc-string? attr-map? [params*] gspec prepost-map? body?]
                     [name doc-string? attr-map? ([params*] gspec prepost-map? body?) + attr-map?])}
        [& forms]
-       (if (emit-specs?)
+       (if (cfg/get-env-config)
          (cond-> (remove nil? (generate-defn forms false (assoc &env :form &form)))
            (cljs-env? &env) clj->cljs)
          (clean-defn 'defn forms)))
@@ -684,7 +684,7 @@
        {:arglists '([name doc-string? attr-map? [params*] gspec prepost-map? body?]
                     [name doc-string? attr-map? ([params*] gspec prepost-map? body?) + attr-map?])}
        [& forms]
-       (if (emit-specs?)
+       (if (cfg/get-env-config)
          (cond-> (remove nil? (generate-defn forms true &env))
            (cljs-env? &env) clj->cljs)
          (clean-defn 'defn- forms)))
@@ -700,7 +700,7 @@
        is intended to be informational for the code reader, currently this is not stored
        anywhere, meaning you can't access this string at runtime."
        ([k spec-form]
-        (when (emit-specs?) 
+        (when (emit-specs?)
           (cond-> `(s/def ~k ~spec-form)
             (cljs-env? &env) clj->cljs)))
        ([k _doc spec-form]

--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -88,8 +88,8 @@
    (do
      (s/def ::defn-macro (s/nilable string?))
      (s/def ::expound (s/nilable (s/map-of keyword? any?)))
-     (s/def ::throw? (s/nilable (s/map-of keyword? any?)))
-     (s/def ::emit-spec? (s/nilable (s/map-of keyword? any?)))
+     (s/def ::throw? (s/nilable boolean?))
+     (s/def ::emit-spec? (s/nilable boolean?))
      (s/def ::log-level #{:trace :debug :info :warn :error :fatal :report})
 
      (s/def ::guardrails-config
@@ -694,10 +694,10 @@
        in production when you want to minimise your build size.
 
        You can optionally send a documentation string as the second parameter, this
-       is intended to be informational for the code reader, current this is not stored
+       is intended to be informational for the code reader, currently this is not stored
        anywhere, meaning you can't access this string at runtime."
        ([k spec-form]
-        (when (cfg/get-env-config)
+        (when (get (cfg/get-env-config) :emit-spec? true) 
           (cond-> `(s/def ~k ~spec-form)
             (cljs-env? &env) clj->cljs)))
        ([k _doc spec-form]

--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -86,10 +86,10 @@
 
 #?(:clj
    (do
-     (s/def ::defn-macro (s/nilable string?))
-     (s/def ::expound (s/nilable (s/map-of keyword? any?)))
-     (s/def ::throw? (s/nilable boolean?))
-     (s/def ::emit-spec? (s/nilable boolean?))
+     (s/def ::defn-macro string?)
+     (s/def ::expound (s/map-of keyword? any?))
+     (s/def ::throw? boolean?)
+     (s/def ::emit-spec? boolean?)
      (s/def ::log-level #{:trace :debug :info :warn :error :fatal :report})
 
      (s/def ::guardrails-config

--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -643,6 +643,9 @@
                                   ~@(process-fn-bodies))]
          `(do ~fdef (declare ~fn-name) ~main-defn)))
 
+     (defmacro emit-specs? []
+       (get (cfg/get-env-config) :emit-spec? true))
+     
      ;;;; Main macros and public API
 
      (s/def ::>defn-args
@@ -664,7 +667,7 @@
        {:arglists '([name doc-string? attr-map? [params*] gspec prepost-map? body?]
                     [name doc-string? attr-map? ([params*] gspec prepost-map? body?) + attr-map?])}
        [& forms]
-       (if (cfg/get-env-config)
+       (if (emit-specs?)
          (cond-> (remove nil? (generate-defn forms false (assoc &env :form &form)))
            (cljs-env? &env) clj->cljs)
          (clean-defn 'defn forms)))
@@ -681,7 +684,7 @@
        {:arglists '([name doc-string? attr-map? [params*] gspec prepost-map? body?]
                     [name doc-string? attr-map? ([params*] gspec prepost-map? body?) + attr-map?])}
        [& forms]
-       (if (cfg/get-env-config)
+       (if (emit-specs?)
          (cond-> (remove nil? (generate-defn forms true &env))
            (cljs-env? &env) clj->cljs)
          (clean-defn 'defn- forms)))
@@ -697,7 +700,7 @@
        is intended to be informational for the code reader, currently this is not stored
        anywhere, meaning you can't access this string at runtime."
        ([k spec-form]
-        (when (get (cfg/get-env-config) :emit-spec? true) 
+        (when (emit-specs?) 
           (cond-> `(s/def ~k ~spec-form)
             (cljs-env? &env) clj->cljs)))
        ([k _doc spec-form]
@@ -718,7 +721,7 @@
        {:arglists '([name [params*] gspec]
                     [name ([params*] gspec) +])}
        [& forms]
-       (when (cfg/get-env-config)
+       (when (emit-specs?)
          (cond-> (remove nil? (generate-fdef &env forms))
            (cljs-env? &env) clj->cljs)))
 


### PR DESCRIPTION
This way projects that pull in guardrails through a transitive deps (unconfigured/missing guardrails.edn) will still by default emit specs. 