### PR TITLE
provide actionable data in the exception thrown

### DIFF
--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -48,12 +48,17 @@
       (when-not (s/valid? spec specable-args)
         (let [problem     (exp/expound-str spec specable-args expound-opts)
               description (str
-                            "\n"
-                            fn-name
-                            (if args? " argument list" " return type") "\n"
-                            problem)]
+                           "\n"
+                           fn-name
+                           (if args? " argument list" " return type") "\n"
+                           problem)]
           (if throw?
-            (reset! valid-exception (ex-info description {}))
+            (reset! valid-exception (ex-info description
+                                             #:com.fulcrologic.guardrails{:_/type :com.fulcrologic.guardrails/validation-error
+                                                                          :fn-name fn-name
+                                                                          :failure-point (if args? :args :ret)
+                                                                          :spec spec
+                                                                          :val specable-args}))
             (utils/report-problem (str description "\n" (utils/stacktrace (ex-info "" {})))))))
       (catch #?(:cljs :default :clj Throwable) e
         (utils/report-exception e (str "BUG: Internal error in expound or clojure spec.\n"))))

--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -48,10 +48,10 @@
       (when-not (s/valid? spec specable-args)
         (let [problem     (exp/expound-str spec specable-args expound-opts)
               description (str
-                           "\n"
-                           fn-name
-                           (if args? " argument list" " return type") "\n"
-                           problem)]
+                            "\n"
+                            fn-name
+                            (if args? " argument list" " return type") "\n"
+                            problem)]
           (if throw?
             (reset! valid-exception (ex-info description
                                              #:com.fulcrologic.guardrails{:_/type :com.fulcrologic.guardrails/validation-error


### PR DESCRIPTION
This adds some ex-data to the ex-info thrown.

a `:type` key to allow easy matching 
`:com.fulcrologic.guardrails{ :spec :val :fn-name :failure-point }` keys to allow to know where/how it failed.

This allows nicer interop with libs such as https://github.com/exoscale/ex but generally also better matching of the exception than just parsing the ex-message.