### PR TITLE
Use new expound version with fix for walking-bug

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths   ["src/main"],
 
- :deps    {expound/expound {:mvn/version "0.8.5"}}
+ :deps    {expound/expound {:mvn/version "0.8.7"}}
 
  :aliases {:test      {:extra-paths ["src/test"]}
 


### PR DESCRIPTION
Crashed when walking eg [datomic](https://www.datomic.com/) db values in specs. See [expound issue](https://github.com/bhb/expound/issues/205).