### PR TITLE
Adding global context hook to enter & leave (ie push/pop) context, fo…

### DIFF
--- a/src/test/com/fulcrologic/guardrails/core_spec.cljc
+++ b/src/test/com/fulcrologic/guardrails/core_spec.cljc
@@ -3,7 +3,7 @@
     [com.fulcrologic.guardrails.core :as gr :refer [>defn =>]]
     [com.fulcrologic.guardrails.config :as config]
     [clojure.spec.alpha :as s]
-    [fulcro-spec.core :refer [specification assertions when-mocking provided]]
+    [fulcro-spec.core :refer [specification assertions component when-mocking provided]]
     [clojure.test :refer [deftest is]]))
 
 #?(:clj


### PR DESCRIPTION
…r use in reporting extra data in spec errors.

Currently used in fulcro-spec to add specification and behavior context to more easily debug guardrails errors.