### PR TITLE
adding config option `:tap>?`, to forward spec errors through `tap>`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -322,7 +322,10 @@ The default config goes in top of project as `guardrails.edn`:
 
  ;; should a spec failure on args or ret throw an execption?
  ;; (always logs an informative message)
- :throw?     false}
+ :throw?     false
+
+ ;; should a spec failure be forwarded through tap> ?
+ :tap?>      false}
 -----
 
 You can override the config file *name* using JVM option


### PR DESCRIPTION
(only if available in your version of clj(s))