### PR TITLE
Update the package name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <name>fulcro</name>
+    <name>guardrails</name>
     <description>A library for using Clojure specs more like a type system during development.</description>
     <url>https://github.com/fulcrologic/guardrails</url>
     <licenses>


### PR DESCRIPTION
This metadata is used in websites like mvnrepository and make it confusing. 
https://mvnrepository.com/artifact/com.fulcrologic/guardrails/1.1.5