### PR TITLE
fixed issue where (>defn-) wasn't generating correct meta-data to mak…

### DIFF
--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -791,6 +791,10 @@
        (>defn- test-function [] [=> nil?] nil)
        (clojure.pprint/pprint (meta #'test-function))
        (assert (true? (:private (meta #'test-function))))
+
+       (>defn test-function2 [] [=> nil?] nil)
+       (assert (nil? (:private (meta #'test-function2))))
+
        ,)
 
      (s/fdef >defn- :args ::>defn-args)

--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -773,7 +773,7 @@
        {:arglists '([name doc-string? attr-map? [params*] gspec prepost-map? body?]
                     [name doc-string? attr-map? ([params*] gspec prepost-map? body?) + attr-map?])}
        [& forms]
-       (>defn* &env &form forms {:private false}))
+       (>defn* &env &form forms {:private? false}))
 
      (s/fdef >defn :args ::>defn-args)
 
@@ -785,7 +785,13 @@
        {:arglists '([name doc-string? attr-map? [params*] gspec prepost-map? body?]
                     [name doc-string? attr-map? ([params*] gspec prepost-map? body?) + attr-map?])}
        [& forms]
-       (>defn* &env &form forms {:private true}))
+       (>defn* &env &form forms {:private? true}))
+
+     (comment
+       (>defn- test-function [] [=> nil?] nil)
+       (clojure.pprint/pprint (meta #'test-function))
+       (assert (true? (:private (meta #'test-function))))
+       ,)
 
      (s/fdef >defn- :args ::>defn-args)
 


### PR DESCRIPTION
arg to defn* was incorrect: {:private} should have been {:private?}