### PR TITLE
Add clj-kondo config with improved hook for >defn

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../src/clj-kondo/clj-kondo.exports/com.fulcrologic/guardrails"]}

--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
-{:paths   ["src/main"],
+{:paths   ["src/main"
+           "src/clj-kondo"],
 
  :deps    {expound/expound        {:mvn/version "0.8.7"}
            org.clojure/core.async {:mvn/version "1.3.618"}}

--- a/src/clj-kondo/clj-kondo.exports/com.fulcrologic/guardrails/com/fulcrologic/guardrails/clj_kondo_hooks.clj
+++ b/src/clj-kondo/clj-kondo.exports/com.fulcrologic/guardrails/com/fulcrologic/guardrails/clj_kondo_hooks.clj
@@ -1,0 +1,61 @@
+(ns com.fulcrologic.guardrails.clj-kondo-hooks
+  (:require [clj-kondo.hooks-api :as api]))
+
+(def =>? #{'=> :ret})
+(def |? #{'| :st})
+
+(defn >defn
+  [{:keys [node]}]
+  (let [args       (rest (:children node))
+        fn-name    (first args)
+        ?docstring (when (string? (api/sexpr (second args)))
+                     (second args))
+        args       (if ?docstring
+                     (nnext args)
+                     (next args))
+        argv       (first args)
+        gspec      (second args)
+        body       (nnext args)
+        new-node   (api/list-node
+                     (list*
+                        (api/token-node 'defn)
+                        fn-name
+                        argv
+                        gspec
+                        body))]
+    ;; gspec: [arg-specs* (| arg-preds+)? => ret-spec (| fn-preds+)? (<- generator-fn)?]
+    (if (not= 1 (count (filter =>? (api/sexpr gspec))))
+      (api/reg-finding! (merge (meta gspec)
+                          {:message (str "Gspec requires exactly one `=>` or `:ret`")
+                           :type    :clj-kondo.fulcro.>defn/invalid-gspec}))
+      (let [p (partition-by (comp not =>? api/sexpr) (:children gspec))
+            [arg [=>] [ret-spec & _output]] (if (-> p ffirst api/sexpr =>?)
+                                              (cons [] p) ; arg-specs might be empty
+                                              p)
+            [arg-specs [| & arg-preds]] (split-with (comp not |? api/sexpr) arg)]
+
+        (when-not ret-spec
+          (println =>)
+          (api/reg-finding! (merge (meta =>)
+                              {:message "Missing return spec."
+                               :type    :clj-kondo.fulcro.>defn/invalid-gspec})))
+
+        ;; (| arg-preds+)?
+        (when (and | (empty? arg-preds))
+          (api/reg-finding! (merge (meta |)
+                              {:message "Missing argument predicates after |."
+                               :type    :clj-kondo.fulcro.>defn/invalid-gspec})))
+
+
+        (let [len-argv (count (remove #{'&} (api/sexpr argv))) ; [a & more] => 2 arguments
+              arg-difference (- (count arg-specs) len-argv)]
+          (when (not (zero? arg-difference))
+            (let [too-many-specs? (pos? arg-difference)]
+              (api/reg-finding! (merge
+                                  (meta (if too-many-specs?
+                                          (nth arg-specs (+ len-argv arg-difference -1)) ; first excess spec
+                                          gspec)) ; The gspec is wrong, not the surplus argument.
+                                  {:message (str "Guardrail spec does not match function signature. "
+                                              "Too " (if too-many-specs? "many" "few") " specs.")
+                                   :type    :clj-kondo.fulcro.>defn/invalid-gspec})))))))
+    {:node new-node}))

--- a/src/clj-kondo/clj-kondo.exports/com.fulcrologic/guardrails/config.edn
+++ b/src/clj-kondo/clj-kondo.exports/com.fulcrologic/guardrails/config.edn
@@ -1,0 +1,6 @@
+{:hooks {:analyze-call {com.fulcrologic.guardrails.core/>defn com.fulcrologic.guardrails.clj-kondo-hooks/>defn
+                        com.fulcrologic.guardrails.core/>defn- com.fulcrologic.guardrails.clj-kondo-hooks/>defn}}
+ :linters {:clj-kondo.fulcro.>defn/invalid-gspec {:level :error}}
+ :lint-as {com.fulcrologic.guardrails.core/>def   clojure.core/def
+           com.fulcrologic.guardrails.core/>defn  clojure.core/defn
+           com.fulcrologic.guardrails.core/>defn- clojure.core/defn-}}


### PR DESCRIPTION
Finally, the PR mentioned in https://github.com/fulcrologic/fulcro/pull/492. 

I tested it in my project:

```sh-session
❯ clj-kondo --copy-configs --dependencies --lint "$(clojure -Spath)"
Imported config to .clj-kondo/com.fulcrologic/guardrails. To activate, add "com.fulcrologic/guardrails" to :config-paths in .clj-kondo/config.edn.
```

TODO: We can kick the guardrails parts from the fulcro clj-kondo config.

-----
# Original PR: [fulcro](https://github.com/fulcrologic/fulcro/pull/492)


The current clj-kondo hook for `>defn` produces a false positive when using argument predicates ("such that").

This would fail because the current implementation counts everything before `=>`:
```clojure
(>defn my-fn [x]
  [::x | #(pos? x) => any?] 
  x)
```

-------------

I took the chance and added some more checks to the gspec validation.

gspec reference:
`[arg-specs* (| arg-preds+)? => ret-spec (| fn-preds+)? (<- generator-fn)?]`

What errors are caught?
- Missing `=>` 
- Missing `ret-spec`
- `|` present but no `arg-preds`
- number of `arg-specs` is not equal to number of arguments

@holyjak Maybe you want to review this as well?