### PR TITLE
Fix clj-kondo hooks, include them in jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ resources/public/workspaces
 !.idea/runConfigurations
 pom.xml.releaseBackup
 release.properties
+/.clj-kondo/*/

--- a/deps.edn
+++ b/deps.edn
@@ -4,9 +4,10 @@
  :deps    {expound/expound        {:mvn/version "0.8.7"}
            org.clojure/core.async {:mvn/version "1.3.618"}}
 
- :aliases {:test      {:extra-paths ["src/test"]
+ :aliases {:test      {:extra-paths ["src/test" "src/test-clj-kondo"]
                        :extra-deps  {org.clojure/test.check  {:mvn/version "1.1.0"}
-                                     fulcrologic/fulcro-spec {:mvn/version "3.1.9"}}}
+                                     fulcrologic/fulcro-spec {:mvn/version "3.1.9"}
+                                     clj-kondo/clj-kondo     {:mvn/version "2022.01.15"}}}
 
            :clj-tests {:extra-paths ["src/test"]
                        :main-opts   ["-m" "kaocha.runner"]
@@ -18,4 +19,3 @@
                                      org.clojure/tools.nrepl     {:mvn/version "0.2.13"}
                                      binaryage/devtools          {:mvn/version "1.0.0"}
                                      org.clojure/tools.namespace {:mvn/version "1.0.0"}}}}}
-

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
       <resource>
         <directory>src/main</directory>
       </resource>
+      <resource>
+        <directory>src/clj-kondo</directory>
+      </resource>
     </resources>
     <plugins>
       <plugin>

--- a/src/clj-kondo/clj-kondo.exports/com.fulcrologic/guardrails/config.edn
+++ b/src/clj-kondo/clj-kondo.exports/com.fulcrologic/guardrails/config.edn
@@ -1,6 +1,6 @@
-{:hooks {:analyze-call {com.fulcrologic.guardrails.core/>defn com.fulcrologic.guardrails.clj-kondo-hooks/>defn
-                        com.fulcrologic.guardrails.core/>defn- com.fulcrologic.guardrails.clj-kondo-hooks/>defn}}
+{:hooks {:analyze-call {com.fulcrologic.guardrails.core/>defn
+                        com.fulcrologic.guardrails.clj-kondo-hooks/>defn
+                        com.fulcrologic.guardrails.core/>defn-
+                        com.fulcrologic.guardrails.clj-kondo-hooks/>defn}}
  :linters {:clj-kondo.fulcro.>defn/invalid-gspec {:level :error}}
- :lint-as {com.fulcrologic.guardrails.core/>def   clojure.core/def
-           com.fulcrologic.guardrails.core/>defn  clojure.core/defn
-           com.fulcrologic.guardrails.core/>defn- clojure.core/defn-}}
+ :lint-as {com.fulcrologic.guardrails.core/>def   clojure.spec.alpha/def}}

--- a/src/test-clj-kondo/com/fulcrologic/guardrails/clj_kondo_hooks_test.clj
+++ b/src/test-clj-kondo/com/fulcrologic/guardrails/clj_kondo_hooks_test.clj
@@ -1,0 +1,151 @@
+(ns com.fulcrologic.guardrails.clj-kondo-hooks-test
+  (:require
+   [clj-kondo.core :as clj-kondo]
+   [clojure.test :refer [deftest is]]))
+
+(defn clj-kondo-findings [input-string]
+  ;; ensure latest hook is used
+  (require '[clj-kondo.impl.hooks] :reload)
+  (-> input-string
+      (with-in-str
+       (clj-kondo/run!
+        {:lint  ["-"]
+         :cache false
+         :config
+         '{:hooks   {:analyze-call
+                     {com.fulcrologic.guardrails.core/>defn
+                      com.fulcrologic.guardrails.clj-kondo-hooks/>defn
+                      com.fulcrologic.guardrails.core/>defn-
+                      com.fulcrologic.guardrails.clj-kondo-hooks/>defn}}
+           :linters {:clj-kondo.fulcro.>defn/invalid-gspec {:level :error}}
+           :lint-as {com.fulcrologic.guardrails.core/>def clojure.spec.alpha/def}}}))
+      (:findings)))
+
+(deftest >defn-hook-happy-path
+  (is (= []
+         (clj-kondo-findings
+          "(ns foo
+  (:require
+    [com.fulcrologic.guardrails.core :refer [>defn]]
+    [clojure.spec.alpha :as s]))
+
+(>defn simples
+  [a]
+  [int? => int?]
+  (if (> a 0)
+    (* a (dec a))
+    1))
+
+(>defn one-list-arity
+  ([b]
+   [int? => int?]
+   (if (> b 0)
+     (* b (dec b))
+     1)))
+
+(>defn docstring
+  \"docstring\"
+  [a]
+  [int? => int?]
+  (if (> a 0)
+    (* a (dec a))
+    1))
+
+(>defn docstring-one-list-arity
+  \"docstring\"
+  ([a]
+   [int? => int?]
+   (if (> a 0)
+     (* a (dec a))
+     1)))
+
+(>defn test-function
+  \"docstring\"
+  ([a]
+   [int? => int?]
+   (if (> a 0)
+     (* a (test-function (dec a)))
+     1))
+  ([a b]
+   [int? int? => int?]
+   (if (> a b)
+     (recur a (inc b))
+     (+ a b)))
+  ([a b c & d]
+   [int? int? int? (s/* int?) => '=> int?]
+   (if (seq d)
+     (reduce + 0 d)
+     (+ a b c))))
+"))))
+
+(deftest >defn-hook-errors
+  (is (= [{:col      3
+           :end-col  27
+           :end-row  8
+           :filename "<stdin>"
+           :level    :error
+           :message  "Gspec requires exactly one `=>` or `:ret`"
+           :row      8
+           :type     :clj-kondo.fulcro.>defn/invalid-gspec}
+          {:col      4
+           :end-col  10
+           :end-row  15
+           :filename "<stdin>"
+           :level    :error
+           :message  "Gspec requires exactly one `=>` or `:ret`"
+           :row      15
+           :type     :clj-kondo.fulcro.>defn/invalid-gspec}
+          {:col      4
+           :end-col  28
+           :end-row  23
+           :filename "<stdin>"
+           :level    :error
+           :message  "Gspec requires exactly one `=>` or `:ret`"
+           :row      23
+           :type     :clj-kondo.fulcro.>defn/invalid-gspec}
+          {:col      10
+           :end-col  22
+           :end-row  23
+           :filename "<stdin>"
+           :level    :error
+           :message  "Unresolved symbol: =wrong-sym=>"
+           :row      23
+           :type     :unresolved-symbol}]
+         (clj-kondo-findings
+          "(ns foo
+  (:require
+    [com.fulcrologic.guardrails.core :refer [>defn]]
+    [clojure.spec.alpha :as s]))
+
+(>defn simples
+  [a]
+  [int? => int? :ret int?]
+  (if (> a 0)
+    (* a (dec a))
+    1))
+
+(>defn one-list-arity
+  ([b]
+   [int?]
+   (if (> b 0)
+     (* b (dec b))
+     1)))
+
+(>defn test-function
+  \"docstring\"
+  ([a]
+   [int? =wrong-sym=> int?]
+   (if (> a 0)
+     (* a (test-function (dec a)))
+     1))
+  ([a b]
+   [int? int? => int?]
+   (if (> a b)
+     (recur a (inc b))
+     (+ a b)))
+  ([a b c & d]
+   [int? int? int? (s/* int?) => int?]
+   (if (seq d)
+     (reduce + 0 d)
+     (+ a b c))))
+"))))

--- a/tests.edn
+++ b/tests.edn
@@ -3,7 +3,12 @@
              :ns-patterns  ["-test$" "-spec$"]
              :test-paths   ["src/test"]
              :skip-meta    [:integration]
-             :source-paths ["src/main"]}]
+             :source-paths ["src/main"]}
+            {:id           :clj-kondo-hooks
+             :ns-patterns  ["-test$" "-spec$"]
+             :test-paths   ["src/test-clj-kondo"]
+             :skip-meta    [:integration]
+             :source-paths ["src/clj-kondo"]}]
  :reporter [fulcro-spec.reporters.terminal/fulcro-report]
  :plugins  []
  :capture-output? false


### PR DESCRIPTION
Fixes #29 
Also fixes the hooks themselves added in #28 so they also work for the multiple arity case and handle gspec symbols.

I haven't been able to properly verify the cljs build however so I'd appreciate someone double-checking that.

~Edit: it appears `clojure -M:test:clj-tests` fails at the moment with the new test, looking into it.~ Edit: fixed before merge