### PR TITLE
linear search over malli default registry & custom guardrail registry

### DIFF
--- a/src/main/com/fulcrologic/guardrails/malli/registry.cljc
+++ b/src/main/com/fulcrologic/guardrails/malli/registry.cljc
@@ -8,11 +8,13 @@
 (defonce ^{:docstring "The atom that holds the schemas that guardrails will use for validating gspecs. This is a public
 atom, and you can choose to manipulate it directly; however, library authors should only add things to this that are
 namespaced to the library itself."}
-  schema-atom (atom (m/default-schemas)))
+  schema-atom (atom {}))
 
-(defonce ^{:docstring "The Malli registry using by guardrails when validating gspecs. It is a mutable registry that
+(defonce ^{:docstring "The Malli registry using by guardrails when validating gspecs. It is a composite registry or malli default registry and mutable registry that
  works from the schema-atom in this ns."}
-  registry (mr/mutable-registry schema-atom))
+  registry (mr/composite-registry
+            m/default-registry
+            (mr/mutable-registry schema-atom)))
 
 (defn register!
   "Register the given keyword with the given schema.

--- a/src/main/com/fulcrologic/guardrails/malli/registry.cljc
+++ b/src/main/com/fulcrologic/guardrails/malli/registry.cljc
@@ -12,9 +12,7 @@ namespaced to the library itself."}
 
 (defonce ^{:docstring "The Malli registry using by guardrails when validating gspecs. It is a composite registry or malli default registry and mutable registry that
  works from the schema-atom in this ns."}
-  registry (mr/composite-registry
-            m/default-registry
-            (mr/mutable-registry schema-atom)))
+  registry (mr/composite-registry m/default-registry (mr/mutable-registry schema-atom)))
 
 (defn register!
   "Register the given keyword with the given schema.


### PR DESCRIPTION
Current code pushes all malli default schemas into the atom. This has some drawbacks:

1. user can accidentally override any default schema, e.g. write `:int` to `(m/-string-schema)`
2. common pattern with malli is to build your mutable registry to application-level, e.g.

```clojure
(require '[malli.core :as m])
(require '[malli.registry :as mr])

(def registry (atom {}))

(defn register! [type schema]
  (swap! registry assoc type schema))

(mr/set-default-registry!
  ;; linear search
  (mr/composite-registry
    ;; core schemas
    (m/default-schemas)
    ;; to support Var references
    (mr/var-registry)
    ;; mutable (spec-like) registry
    (mr/mutable-registry registry)))
```

this PR changes the registry to be a `composite registry` (linear seach) over the following:

1. `malli.core/default-registry` -> users can define this into anything, see above. If user has already a mutable registry, those are automatically available with guardrails. Also, in ClojureScript, one can just register few basic schemas for smaller bundle size (malli starts with 2kb gzipped)
2. the guardrail default registry.

having 1 separated from 2 also means one can't override the base schemas, e.g. `:int` is always `:int`.

