### PR TITLE
Fix bug in malli schema merge

### DIFF
--- a/src/main/com/fulcrologic/guardrails/malli/registry.cljc
+++ b/src/main/com/fulcrologic/guardrails/malli/registry.cljc
@@ -24,6 +24,7 @@ namespaced to the library itself."}
   "Add the given Malli schemas to the GR registry. All of Malli's default-schemas are merged by default.
    schemas."
   [& schemas]
-  (swap! schema-atom apply merge schemas))
+  (let [combined (apply merge schemas)]
+    (swap! schema-atom merge combined)))
 
 (register! :every (m/-collection-schema {:type :every, :pred coll?}))


### PR DESCRIPTION
Consider the following calls as they are executed on main branch:
```
(gr.reg/merge-schemas! {:x :string})
=> {:x :string}
(gr.reg/merge-schemas! {:y :string})
=> {:y :string}
```
Seems odd that each merge overrides previous value? There's a bug:
```
(defn merge-schemas!
  "Add the given Malli schemas to the GR registry. All of Malli's default-schemas are merged by default.
   schemas."
  [& schemas]
  (swap! schema-atom apply merge schemas))
```

So this swap executes: `(apply prev-value merge schemas)`, so the current value of schemas acts a a function, looks up `merge` fn in that map, which is not a valid key of course, then returns the schema as the default.

It is more obvious when we supply more schema maps:

```
(gr.reg/merge-schemas! {:y :string} {:z :string})
Execution error (ArityException) at com.fulcrologic.guardrails.malli.registry/merge-schemas! (registry.cljc:27).
Wrong number of args (3) passed to: clojure.lang.PersistentArrayMap
```

