### PR TITLE
Remove core async

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -505,13 +505,13 @@ NOTE: As a library *author* these exclusions will end up applying to your code a
 
 NOTE: This is an older attempt at helping performance, and it is moderately helpful when you want exhaustive checking in Clojure. In general, you should instead prefer the use of exclusions or the max checks per second setting at the namespace, function, or project level.
 
-Guardrails has an asynchronous checking mode (which mainly benefits Clojure).
+Guardrails has an asynchronous checking mode for Clojure.
 
-When this mode is enabled it pushes spec checking into a `core.async` channel with a dropping buffer (size 10,000). The overhead for the `put` is just a few microseconds. This allows an alternate thread to run the checks, and as long as you don't have large sustained computations this can give you nearly full-production performance of your code, while an alternate core in your computer handles the checks.
+When this mode is enabled it pushes spec checking into a queue with a dropping buffer (size 10,000), which is processed by another thread. The overhead for the `put` is just a few microseconds. This allows an alternate thread to run the checks, and as long as you don't have large sustained computations this can give you nearly full-production performance of your code, while an alternate core in your computer handles the checks.
 
 Benefits:
 
-* Much faster dev performance (Clojure only. The option works in CLJS, but there's not a second thread so there is no benefit).
+* Much faster dev performance (Clojure only. The option does nothing in CLJS).
 * High performance algorithms can use guardrails with a tolerable cost.
 
 Costs:

--- a/README.adoc
+++ b/README.adoc
@@ -366,9 +366,6 @@ The default config goes in the root of the project as `guardrails.edn`:
  :expound    {:show-valid-values? true
               :print-specs?       true}
 
- ;; Check specs in parallel (CLJ only)
- :async?     true
-
  ;; GLOBALLY enable non-exhaustive checking (this is NOT recommended, you'd
  ;; usually want to set it in a more granular fashion on the function or
  ;; namespace level using metadata.)
@@ -500,30 +497,6 @@ A quick implementation note: In order to make this work in Clojurescript a macro
 The set of exclusions found in export files at load time is what `reset-exclusions!` will restore if you have dynamically changed the exclusions at runtime. Basically this load-time set is kept in a var for exactly this reason since CLJS cannot re-trigger a classpath scan.
 
 NOTE: As a library *author* these exclusions will end up applying to your code as well, since it is difficult to tell which export file belongs to which project on the classpath. Thus the beginning of your test namespaces (and possibly your non-published user ns) should all start with a call to `config/clear-exclusions!` if you want to include your implementation checks while running your tests and working on your library code.
-
-=== Async Mode for Clojure (not useful in CLJS)
-
-NOTE: This is an older attempt at helping performance, and it is moderately helpful when you want exhaustive checking in Clojure. In general, you should instead prefer the use of exclusions or the max checks per second setting at the namespace, function, or project level.
-
-Guardrails has an asynchronous checking mode for Clojure.
-
-When this mode is enabled it pushes spec checking into a queue with a dropping buffer (size 10,000), which is processed by another thread. The overhead for the `put` is just a few microseconds. This allows an alternate thread to run the checks, and as long as you don't have large sustained computations this can give you nearly full-production performance of your code, while an alternate core in your computer handles the checks.
-
-Benefits:
-
-* Much faster dev performance (Clojure only. The option does nothing in CLJS).
-* High performance algorithms can use guardrails with a tolerable cost.
-
-Costs:
-
-* Checking results are queued. If a lot of slow checks get in the queue you might have to wait some time before you see the problems. This could cause confusion (you might be running your next expression in the REPL and see an error from the prior one).
-* Not all checks will run in a CPU-intensive task that queues checks rapidly.
-* Async mode is incompatible with the `:throw? true` option.
-
-To enable the async mode, just add `:async? true` in your `guardrails.edn` file.
-
-This mode does not benefit clojurescript because there *is no* alternate thread to push the checks to.
-
 
 == Why?
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,7 @@
 {:paths   ["src/main"
            "src/clj-kondo"],
 
- :deps    {expound/expound        {:mvn/version "0.9.0"}
-           org.clojure/core.async {:mvn/version "1.6.673"}}
+ :deps    {expound/expound        {:mvn/version "0.9.0"}}
 
  :aliases {:test      {:extra-paths ["src/test" "src/test-clj-kondo"]
                        :extra-deps  {org.clojure/test.check  {:mvn/version "1.1.1"}

--- a/pom.xml
+++ b/pom.xml
@@ -74,10 +74,5 @@
             <artifactId>expound</artifactId>
             <version>0.9.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.clojure</groupId>
-            <artifactId>core.async</artifactId>
-            <version>1.6.673</version>
-        </dependency>
     </dependencies>
 </project>

--- a/src/main/com/fulcrologic/guardrails/config.cljc
+++ b/src/main/com/fulcrologic/guardrails/config.cljc
@@ -108,9 +108,6 @@
 (defn mode [config]
   (get config :mode :runtime))
 
-(defn async? [config]
-  (get config :async? false))
-
 (def default-config
   {;; Generates standard `defn` function definitions
    ;; by default. If you require composability with other
@@ -151,15 +148,10 @@
                                         cljs-compiler-config
                                         (System/getProperty "guardrails.enabled"))
                                 :cljs false)
-                         (let [{:keys [async? throw?] :as result} (merge {} (read-config-file) cljs-compiler-config)
-                               result (if (and async? throw?)
-                                        (dissoc result :async?)
-                                        result)]
+                         (let [result (merge {} (read-config-file) cljs-compiler-config)]
                            (when-not @warned?
                              (reset! warned? true)
                              (utils/report-info "GUARDRAILS IS ENABLED. RUNTIME PERFORMANCE WILL BE AFFECTED.")
-                             (when (and async? throw?)
-                               (utils/report-problem "INCOMPATIBLE MODES: :throw? and :async? cannot both be true. Disabling async."))
                              (utils/report-info (str "Mode: " (mode result) (when (= :runtime (mode result))
                                                                               (str "  config: " result))))
                              (utils/report-info (str "Guardrails was enabled because "

--- a/src/main/com/fulcrologic/guardrails/noop.cljc
+++ b/src/main/com/fulcrologic/guardrails/noop.cljc
@@ -15,7 +15,7 @@
   WARNING: Make sure you don't need the specs at runtime for anything. Use `s/def` for those, and
   `>def` for ones that you want to disappear at runtime.
 
-  This will also eliminate the guardrails requires of things like expound, core.async, and core.stacktrace."
+  This will also eliminate the guardrails requires of things like expound, and core.stacktrace."
   #?(:cljs (:require-macros com.fulcrologic.guardrails.noop)))
 
 (def => :ret)


### PR DESCRIPTION
From:
```
(time (require '[com.fulcrologic.guardrails.malli.core]))
"Elapsed time: 7330.943292 msecs"
```
 to
```
(time (require '[com.fulcrologic.guardrails.malli.core]))
"Elapsed time: 3880.868583 msecs"
```