### PR TITLE
Allow symbol based >def for Malli

### DIFF
--- a/src/main/com/fulcrologic/guardrails/malli/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/malli/core.cljc
@@ -86,7 +86,9 @@
            mode (gr.cfg/mode cfg)]
        ;; NOTE: Possibly manual override to always include them?
        (when (and cfg (#{:runtime :all} mode))
-         `(register! ~k ~v)))))
+         (if (symbol? k)
+           `(do (def ~k ~v) @gr.reg/schema-atom)
+           `(register! ~k ~v))))))
 
 (defn validate [schema value] (m/validate schema value {:registry gr.reg/registry}))
 (defn explain [schema value] (m/explain schema value {:registry gr.reg/registry}))


### PR DESCRIPTION
In Malli, user is encouraged to use data structures directly to represent schemas, rather than use various registry solutions. For simple, but often used schemas like "a date", it's intended to register a schema, but for schemas that are used in 1 or 2 places you can just declare the data structure as a var and use them. In fact here's the Quickstart section of malli's readme:

```
(require '[malli.core :as m])

(def UserId :string)

(def Address
  [:map
   [:street :string]
   [:country [:enum "FI" "UA"]]])

(def User
  [:map
   [:id #'UserId]
   [:address #'Address]
   [:friends [:set {:gen/max 2} [:ref #'User]]]])

(require '[malli.generator :as mg])

(mg/generate User)
;{:id "AC",
; :address {:street "mf", :country "UA"},
; :friends #{{:id "1dm",
;             :address {:street "8", :country "UA"},
;             :friends #{}}}}

(m/validate User *1)
; => true
```

Guardrails uses macros like `>def` and `>defn`  to exclude generating schemas if guardrails is not enabled. However this doesn't work well with the pattern above, those data defs are not excluded. So I was looking at how `>def` and `>defn` interact with malli schemas in variables.

```
(>def UserId :string)
Unable to resolve symbol: UserId in this context

(>defn x [y]
  [UserId => int?]
  1)
Unable to resolve symbol: UserId in this context
```

The `>defn` function actually works fine. Provided you've got the symbol bound to a malli schema will work correctly. 

The thing with `>def` is that it makes little sense to use the symbol passed into the macro as lookup for the name of the schema. The way it works currently has a positive in that it works if you use it to programatically add schemas with it:

```
(let [schemas {:x :string
               :y :int}]
  (run! #(>def (key %) (val %)) schemas))
```
After the change I've made this is no longer possible. But my change makes the usual malli flow possible, if a symbol is given, a normal def will be used so this works after the patch:
```
(>def UserId :string)

(>defn x [y]
  [UserId => int?]
  1)
```

Another idea is to have separate `>def` for defining as a var and for registering as a schema into schema registry. If we did that, we would have both options. However then there's the issue with having parity with noop and spec namespaces...

