### PR TITLE
Add :guardrails/no-color? option to disable ANSI escape codes

### DIFF
--- a/guardrails.edn
+++ b/guardrails.edn
@@ -2,6 +2,7 @@
  :throw?                 true
  :guardrails/compact?    true
  :guardrails/trace?      true
+ :guardrails/no-color?   false
  :guardrails/stack-trace :none
  :expound                {:show-valid-values? true
                           :print-specs?       true}}

--- a/src/main/com/fulcrologic/guardrails/core.cljc
+++ b/src/main/com/fulcrologic/guardrails/core.cljc
@@ -95,7 +95,7 @@
     (with-out-str
       ((exp/custom-printer expound-options) explain-data))))
 
-(defn run-check [{:guardrails/keys [malli? compact? use-stderr? validate-fn explain-fn fqnm humanize-fn]
+(defn run-check [{:guardrails/keys [malli? compact? use-stderr? no-color? validate-fn explain-fn fqnm humanize-fn]
                   :keys            [tap>? args? vararg? humanize-opts throw? fn-name]
                   :as              options}
                  spec
@@ -122,11 +122,12 @@
                                                           :guardrails/fqnm fqnm
                                                           :guardrails/args? args?))
                 e             (ex-info "" {})
-                description   (utils/problem-description
-                                (str
-                                  "\nGuardrails:\n"
-                                  explain-human)
-                                e options)
+                description   (cond-> (utils/problem-description
+                                        (str
+                                          "\nGuardrails:\n"
+                                          explain-human)
+                                        e options)
+                                no-color? strip-colors)
                 context       (get-global-context)]
             (utils/record-failure fqnm e)
             (when (and tap tap>?)
@@ -771,7 +772,7 @@
      [cfg fn-tail]
      (let [{:keys                                                      [env fn-name]
             {max-checks-per-second :guardrails/mcps
-             :guardrails/keys      [use-stderr? compact? trace? stack-trace]
+             :guardrails/keys      [use-stderr? compact? trace? stack-trace no-color?]
              :keys                 [throw? tap>? disable-exclusions?]} :config} cfg
            {:guardrails/keys [validate-fn explain-fn humanize-fn malli?]} env
            cljs?           (cljs-env? env)
@@ -802,6 +803,7 @@
                             :guardrails/compact?    compact?
                             :guardrails/stack-trace stack-trace
                             :guardrails/use-stderr? use-stderr?
+                            :guardrails/no-color?   no-color?
                             :guardrails/malli?      malli?
                             :tap>?                  tap>?
                             :throw?                 throw?

--- a/src/test/com/fulcrologic/guardrails/malli/core_spec.cljc
+++ b/src/test/com/fulcrologic/guardrails/malli/core_spec.cljc
@@ -1,7 +1,8 @@
 (ns com.fulcrologic.guardrails.malli.core-spec
   (:require
-    [com.fulcrologic.guardrails.malli.core :refer [=> >def >defn |]]
-    [fulcro-spec.core :refer [=throws=> assertions specification]]
+    [com.fulcrologic.guardrails.core :as gr.core]
+    [com.fulcrologic.guardrails.malli.core :as mc :refer [=> >def >defn |]]
+    [fulcro-spec.core :refer [=throws=> assertions specification component]]
     [malli.core :as m]))
 
 #?(:clj
@@ -105,3 +106,34 @@
     (f 14 10) => 24
     "Invalid case throws an error"
     (f 10 14) =throws=> #"Return"))
+
+(specification "no-color? option"
+  (let [opts {:fn-name                "test"
+              :guardrails/fqnm        "test/f"
+              :guardrails/compact?    true
+              :guardrails/malli?      true
+              :guardrails/validate-fn mc/validate
+              :guardrails/explain-fn  mc/explain
+              :guardrails/humanize-fn mc/humanize-schema
+              :throw?                 true
+              :args?                  true
+              :humanize-opts          {}}
+        ansi-re #"\033\["]
+    (component "with no-color? true, error has no ANSI codes"
+      (let [msg (try
+                  (gr.core/run-check (assoc opts :guardrails/no-color? true) :int "bad")
+                  nil
+                  (catch #?(:clj Exception :cljs :default) e
+                    (ex-message e)))]
+        (assertions
+          msg =fn=> some?
+          (re-find ansi-re msg) => nil)))
+    (component "without no-color?, error contains ANSI codes"
+      (let [msg (try
+                  (gr.core/run-check (assoc opts :guardrails/no-color? false) :int "bad")
+                  nil
+                  (catch #?(:clj Exception :cljs :default) e
+                    (ex-message e)))]
+        (assertions
+          msg =fn=> some?
+          (re-find ansi-re msg) =fn=> some?)))))


### PR DESCRIPTION
## Summary

- Adds `:guardrails/no-color?` config option that strips ANSI color escape codes from error messages
- Uses the existing `strip-colors` utility in `utils.cljc` applied to the final error description in `run-check`
- Covers both the custom Guardrails reporter and the upstream Malli prettifier output paths

Closes #48

## Usage

```edn
;; guardrails.edn
{:guardrails/no-color? true}
```

## Test plan

- [x] All existing tests pass (37 tests, 131 assertions, 0 failures)
- [ ] Manual verification: error output with `:guardrails/no-color? true` contains no `\033[` sequences
- [ ] Manual verification: error output without the option (or `false`) retains colors as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)